### PR TITLE
Fix code scanning alert #3: Use of `Kernel.open` or `IO.read` or similar sinks with a non-constant value

### DIFF
--- a/script/i18n/xmltoyml.rb
+++ b/script/i18n/xmltoyml.rb
@@ -37,7 +37,7 @@ copyright = "#   Copyright (c) 2010-2011, Diaspora Inc.  This file is\n#   licen
 data.each do |destfile, sourcefile|
   if File.exists?(sourcefile)
     source = open(sourcefile)
-    dest = open(destfile, 'w')
+    dest = File.open(destfile, 'w')
     dest.write Hash.from_xml(source)['hash'].to_yaml.gsub('---', copyright)
     dest.close
   else

--- a/script/i18n/xmltoyml.rb
+++ b/script/i18n/xmltoyml.rb
@@ -37,7 +37,7 @@ copyright = "#   Copyright (c) 2010-2011, Diaspora Inc.  This file is\n#   licen
 data.each do |destfile, sourcefile|
   if File.exists?(sourcefile)
     source = open(sourcefile)
-    dest = File.open(destfile, 'w')
+    dest = File.open(destfile, "w")
     dest.write Hash.from_xml(source)['hash'].to_yaml.gsub('---', copyright)
     dest.close
   else


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/diaspora/security/code-scanning/3](https://github.com/cooljeanius/diaspora/security/code-scanning/3)

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
