### PR TITLE
Fix code scanning alert #5: Use of `Kernel.open` or `IO.read` or similar sinks with a non-constant value

### DIFF
--- a/script/i18n/ymltoxml.rb
+++ b/script/i18n/ymltoxml.rb
@@ -30,7 +30,7 @@ data = { "config/locales/diaspora/#{locale}.yml" => "xml_locales/#{locale}.xml",
 data.each do |sourcefile, destfile|
   if File.exists?(sourcefile)
     source = YAML.load open(sourcefile)
-    dest = File.open(destfile, 'w')
+    dest = File.open(destfile, "w")
     dest.write source.to_xml
     dest.close
     puts "Generated #{destfile}"

--- a/script/i18n/ymltoxml.rb
+++ b/script/i18n/ymltoxml.rb
@@ -30,7 +30,7 @@ data = { "config/locales/diaspora/#{locale}.yml" => "xml_locales/#{locale}.xml",
 data.each do |sourcefile, destfile|
   if File.exists?(sourcefile)
     source = YAML.load open(sourcefile)
-    dest = open(destfile, 'w')
+    dest = File.open(destfile, 'w')
     dest.write source.to_xml
     dest.close
     puts "Generated #{destfile}"


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/diaspora/security/code-scanning/5](https://github.com/cooljeanius/diaspora/security/code-scanning/5)

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
