### PR TITLE
Fix code scanning alert #4505: Use of `Kernel.open` or `IO.read` or similar sinks with a non-constant value

### DIFF
--- a/script/i18n/ymltoxml.rb
+++ b/script/i18n/ymltoxml.rb
@@ -29,7 +29,7 @@ data = { "config/locales/diaspora/#{locale}.yml" => "xml_locales/#{locale}.xml",
 
 data.each do |sourcefile, destfile|
   if File.exists?(sourcefile)
-    source = YAML.load File.open(sourcefile)
+    source = YAML.safe_load File.open(sourcefile)
     dest = File.open(destfile, "w")
     dest.write source.to_xml
     dest.close

--- a/script/i18n/ymltoxml.rb
+++ b/script/i18n/ymltoxml.rb
@@ -29,7 +29,7 @@ data = { "config/locales/diaspora/#{locale}.yml" => "xml_locales/#{locale}.xml",
 
 data.each do |sourcefile, destfile|
   if File.exists?(sourcefile)
-    source = YAML.load open(sourcefile)
+    source = YAML.load File.open(sourcefile)
     dest = File.open(destfile, "w")
     dest.write source.to_xml
     dest.close


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/diaspora/security/code-scanning/4505](https://github.com/cooljeanius/diaspora/security/code-scanning/4505)

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
