### PR TITLE
Fix code scanning alert #4503: Use of `Kernel.open` or `IO.read` or similar sinks with a non-constant value

### DIFF
--- a/script/i18n/xmltoyml.rb
+++ b/script/i18n/xmltoyml.rb
@@ -36,7 +36,7 @@ copyright = "#   Copyright (c) 2010-2011, Diaspora Inc.  This file is\n#   licen
 
 data.each do |destfile, sourcefile|
   if File.exists?(sourcefile)
-    source = open(sourcefile)
+    source = File.open(sourcefile)
     dest = File.open(destfile, "w")
     dest.write Hash.from_xml(source)['hash'].to_yaml.gsub('---', copyright)
     dest.close


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/diaspora/security/code-scanning/4503](https://github.com/cooljeanius/diaspora/security/code-scanning/4503)

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
