### PR TITLE
Fix code scanning alert #19: Bad HTML filtering regexp

### DIFF
--- a/spec/javascripts/app/helpers/handlebars-helpers_spec.js
+++ b/spec/javascripts/app/helpers/handlebars-helpers_spec.js
@@ -2,7 +2,7 @@ describe("Handlebars helpers", function() {
   describe("sharingMessage", function() {
     it("escapes the person's name", function() {
       var person = { name: "\"><script>alert(0)</script> \"><script>alert(0)</script>"};
-      expect(Handlebars.helpers.sharingMessage(person)).not.toMatch(/<script>/);
+      expect(Handlebars.helpers.sharingMessage(person)).not.toMatch(/<script>/i);
     });
   });
 });


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/diaspora/security/code-scanning/19](https://github.com/cooljeanius/diaspora/security/code-scanning/19)

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
