### PR TITLE
Fix code scanning alert #21: Unsafe HTML constructed from library input

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "node-sass": "^9.0.0",
     "perfect-scrollbar": "1.5.5",
     "pica": "9.0.1",
-    "sass": "^1.78.0"
+    "sass": "^1.78.0",
+    "striptags": "^3.2.0"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^7.18.0",

--- a/vendor/assets/javascripts/jquery.autoSuggest.custom.js
+++ b/vendor/assets/javascripts/jquery.autoSuggest.custom.js
@@ -18,6 +18,7 @@
  *   http://www.opensource.org/licenses/mit-license.php
  *   http://www.gnu.org/licenses/gpl.html
  */
+const striptags = require('striptags');
 
 (function($){
 	$.fn.autoSuggest = function(data, options) {
@@ -320,7 +321,7 @@
 					}
 					selections_holder.removeClass("loading");
 					if(matchCount <= 0){
-						results_ul.html('<li class="as-message">'+opts.emptyText+'</li>');
+						results_ul.html('<li class="as-message">'+striptags(opts.emptyText)+'</li>');
 					}
 					results_ul.css("width", selections_holder.outerWidth());
 					results_holder.show();


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/diaspora/security/code-scanning/21](https://github.com/cooljeanius/diaspora/security/code-scanning/21)

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
