### PR TITLE
Fix code scanning alert #20: Unsafe HTML constructed from library input

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "node-sass": "^9.0.0",
     "perfect-scrollbar": "1.5.5",
     "pica": "9.0.1",
-    "sass": "^1.78.0"
+    "sass": "^1.78.0",
+    "striptags": "^3.2.0"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^7.18.0",

--- a/vendor/assets/javascripts/jquery.autoSuggest.custom.js
+++ b/vendor/assets/javascripts/jquery.autoSuggest.custom.js
@@ -19,6 +19,7 @@
  *   http://www.gnu.org/licenses/gpl.html
  */
 
+const striptags = require('striptags');
 (function($){
 	$.fn.autoSuggest = function(data, options) {
 		var defaults = {
@@ -211,7 +212,7 @@
 						default:
 							if(opts.showResultList){
 								if(opts.selectionLimit && $("li.as-selection-item", selections_holder).length >= opts.selectionLimit){
-									results_ul.html('<li class="as-message">'+opts.limitText+'</li>');
+									results_ul.html('<li class="as-message">'+striptags(opts.limitText)+'</li>');
 									results_holder.show();
 								} else {
 									if (timeout){ clearTimeout(timeout); }


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/diaspora/security/code-scanning/20](https://github.com/cooljeanius/diaspora/security/code-scanning/20)

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
