### PR TITLE
Potential fix for code scanning alert no. 7: Incomplete string escaping or encoding

### DIFF
--- a/config/initializers/json_escape.rb
+++ b/config/initializers/json_escape.rb
@@ -5,7 +5,7 @@
 
 class ActionView::Base
   def json_escape(s)
-    result = s.to_s.gsub('/', '\/')
+    result = s.to_s.gsub('\\', '\\\\').gsub('/', '\/')
     s.html_safe? ? result.html_safe : result
   end
 


### PR DESCRIPTION
Potential fix for [https://github.com/cooljeanius/diaspora/security/code-scanning/7](https://github.com/cooljeanius/diaspora/security/code-scanning/7)

To fix the problem, we need to ensure that all backslashes in the input string are properly escaped. This can be achieved by modifying the `json_escape` method to replace backslashes with double backslashes before replacing forward slashes. This ensures that both backslashes and forward slashes are correctly escaped.

- Modify the `json_escape` method to first escape backslashes by replacing them with double backslashes.
- Then, escape forward slashes by replacing them with `\/`.
- Ensure that the method still returns an HTML-safe string if the input was HTML-safe.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
