### PR TITLE
Potential fix for code scanning alert no. 1: URL redirection from remote source

### DIFF
--- a/app/controllers/api/openid_connect/authorizations_controller.rb
+++ b/app/controllers/api/openid_connect/authorizations_controller.rb
@@ -198,10 +198,20 @@ module Api
         end
       end
 
+      VALID_REDIRECT_URIS = [
+        "https://example.com/callback",
+        "https://example.org/return"
+      ].freeze
+
       def redirect_prompt_error_display(error, error_description)
         redirect_params_hash = {error: error, error_description: error_description, state: params[:state]}
         redirect_fragment = redirect_params_hash.compact.map {|key, value| key.to_s + "=" + value }.join("&")
-        redirect_to params[:redirect_uri] + "?" + redirect_fragment
+        target_uri = params[:redirect_uri]
+        if VALID_REDIRECT_URIS.include?(target_uri)
+          redirect_to target_uri + "?" + redirect_fragment
+        else
+          redirect_to "/error.html"
+        end
       end
 
       def auth_user_unless_prompt_none!

--- a/app/controllers/api/openid_connect/authorizations_controller.rb
+++ b/app/controllers/api/openid_connect/authorizations_controller.rb
@@ -205,10 +205,17 @@ module Api
 
       def redirect_prompt_error_display(error, error_description)
         redirect_params_hash = {error: error, error_description: error_description, state: params[:state]}
-        redirect_fragment = redirect_params_hash.compact.map {|key, value| key.to_s + "=" + value }.join("&")
+        redirect_query = redirect_params_hash.compact.to_query
         target_uri = params[:redirect_uri]
+
         if VALID_REDIRECT_URIS.include?(target_uri)
-          redirect_to target_uri + "?" + redirect_fragment
+          begin
+            uri = URI.parse(target_uri)
+            uri.query = [uri.query, redirect_query].compact.reject(&:empty?).join("&")
+            redirect_to uri.to_s
+          rescue URI::InvalidURIError
+            redirect_to "/error.html"
+          end
         else
           redirect_to "/error.html"
         end


### PR DESCRIPTION
Potential fix for [https://github.com/cooljeanius/diaspora/security/code-scanning/1](https://github.com/cooljeanius/diaspora/security/code-scanning/1)

To fix the problem, we need to validate the `redirect_uri` parameter before using it in the `redirect_to` method. We can do this by maintaining a list of authorized redirect URIs on the server and checking the user-provided `redirect_uri` against this list. If the `redirect_uri` is not in the list, we should redirect to a safe error page.

**Steps to fix:**
1. Define a list of valid redirect URIs.
2. Check if the `redirect_uri` provided in the `params` is in the list of valid URIs.
3. If valid, proceed with the redirection. If not, redirect to an error page.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
