### PR TITLE
Potential fix for code scanning alert no. 4848: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 ---
 name: CI
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/cooljeanius/diaspora/security/code-scanning/4848](https://github.com/cooljeanius/diaspora/security/code-scanning/4848)

Add an explicit `permissions` block to `.github/workflows/ci.yml` at the workflow root so it applies to all jobs (including `test`) unless overridden.  
The least-privilege minimal fix that preserves behavior is:

```yml
permissions:
  contents: read
```

This is sufficient for checkout and typical read-only CI tasks and does not grant any write scopes.  
Change location: directly under `name: CI` (before `on:`), in `.github/workflows/ci.yml`.  
No imports/methods/dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
